### PR TITLE
fix: update tx_code check

### DIFF
--- a/packages/issuer/lib/tokens/index.ts
+++ b/packages/issuer/lib/tokens/index.ts
@@ -110,7 +110,7 @@ export const assertValidAccessTokenRequest = async (
   invalid_request:
   the Authorization Server does not expect a PIN in the pre-authorized flow but the client provides a PIN
    */
-  if (!credentialOfferSession.credentialOffer.credential_offer?.grants?.[GrantTypes.PRE_AUTHORIZED_CODE]?.user_pin_required && request.user_pin) {
+  if (!credentialOfferSession.credentialOffer.credential_offer?.grants?.[GrantTypes.PRE_AUTHORIZED_CODE]?.tx_code && request.user_pin) {
     throw new TokenError(400, TokenErrorResponse.invalid_request, USER_PIN_NOT_REQUIRED_ERROR)
   }
   /*


### PR DESCRIPTION
One check missed the update to draft 13, so it failed all the time, so the left side was always true.

The value `user_pin_required` is still in the `GrantUrnIetf` and could confuse people, maybe a deprecated warning would be helpful. Or we ignore it and hope until version 1 is out to tidy up.